### PR TITLE
Fix GroupedCampaignDialog sizing

### DIFF
--- a/plugins/polio/js/src/pages/GroupedCampaigns/GroupedCampaignDialog.tsx
+++ b/plugins/polio/js/src/pages/GroupedCampaigns/GroupedCampaignDialog.tsx
@@ -99,7 +99,7 @@ export const GroupedCampaignDialog: FunctionComponent<Props> = ({
             onConfirm={onConfirm}
             confirmMessage={MESSAGES.save}
             cancelMessage={MESSAGES.close}
-            maxWidth="md"
+            maxWidth="sm"
             titleMessage={MESSAGES.editGroupedCampaign}
             onCancel={onCancel}
             dataTestId="grouped-campaigns-modal"
@@ -119,7 +119,7 @@ export const GroupedCampaignDialog: FunctionComponent<Props> = ({
                     direction="row"
                     justifyContent="space-around"
                 >
-                    <Grid container item xs={6}>
+                    <Grid container item xs={12}>
                         <Grid item xs={12}>
                             <InputComponent
                                 keyValue={GROUPED_CAMPAIGN_NAME}


### PR DESCRIPTION
## Summary
- reduce dialog width
- keep grid container width consistent

## Testing
- `npm run test` *(fails: mocha not found)*